### PR TITLE
fix overload method generation

### DIFF
--- a/src/ast_method.hpp
+++ b/src/ast_method.hpp
@@ -27,6 +27,9 @@
 
 NS_AST_BEGIN
 
+typedef std::map<std::string, std::string> MethodSignIdMap;
+typedef std::map<std::string, MethodSignIdMap> MethodNameMap;
+
 class Method: public Member
 {
 public:
@@ -52,6 +55,8 @@ private:
     static const int FLAG_AS_C_BUFFER;
     static const int FLAG_SIMPLE_NAME;
 
+    static MethodNameMap s_method_name_id_map;
+
     bool _has_string_arg();
 
     void _build_class_id(std::ostream &os);
@@ -64,6 +69,7 @@ private:
     void _build_c_func_impl_void_type_statement(std::ostream &os, int flags);
     void _build_c_func_impl_reference_type_statement(std::ostream &os, int flags);
     void _build_c_func_impl_basic_type_statement(std::ostream &os, int flags);
+    void _build_c_func_overload_statements(std::ostream &os, int flags);
 
 public:
     virtual void build_c_func_decl(std::ostream &os) override;


### PR DESCRIPTION
增加重载方法(同名不同参)的处理、自动生成
本来想模仿javah生成的头文件一样使用类似__Ljava_lang_String_2Ljava_lang_Object_2的后缀来区分重载方法的，但是觉得太麻烦就用数字后缀了